### PR TITLE
python 2.5 compatibility

### DIFF
--- a/speedtracer/middleware.py
+++ b/speedtracer/middleware.py
@@ -172,7 +172,7 @@ class SpeedTracerMiddleware(object):
                     'range': self._build_range(start_time, end_time),
                     'operation':  {
                         'type':  'HTTP',
-                        'label':  "{0.method} {0.path}".format(request)
+                        'label':  "%s %s" % (request.method, request.path)
                     },
                     'children': self.traces,
                 }


### PR DESCRIPTION
speedtracer looks cool - doesn't work on my python 2.5 though :(

Here's a minor fix which seems to work (still works in py3 also)
